### PR TITLE
include limits.h in rx.c

### DIFF
--- a/rx.c
+++ b/rx.c
@@ -23,6 +23,8 @@
 #include "wifibroadcast.h"
 #include "radiotap.h"
 
+#include <limits.h>
+
 #define MAX_PACKET_LENGTH 4192
 #define MAX_USER_PACKET_LENGTH 1450
 #define MAX_DATA_OR_FEC_PACKETS_PER_BLOCK 32


### PR DESCRIPTION
Cross compiling the code for openwrt I encountered a missing limits.h include in the rx.c file.